### PR TITLE
Upgrade pyyaml to version 4.2b1 security reasons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ statsmodels
 scipy
 lxml
 python-dotenv
-pyyaml==3.13
+pyyaml==4.2b1
 tabulate==0.8.2
 requests==2.20.0
 ujson==1.35


### PR DESCRIPTION
Upgrade pyyaml to version 4.2b1 for security reasons